### PR TITLE
Do not return email on logging process

### DIFF
--- a/src/main/kotlin/barter/barter_it_api/domain/user/user.kt
+++ b/src/main/kotlin/barter/barter_it_api/domain/user/user.kt
@@ -27,8 +27,7 @@ data class UserAuthRequest (
 
 data class UserLoginResponse(
         val token: AccessToken,
-        val id: String?,
-        val email: String
+        val id: String?
 )
 
 data class AccessToken(
@@ -42,6 +41,5 @@ fun UserAuthRequest.toUser(encodedPassword: String) = User(
 
 fun User.toUserLoginResponse(token: AccessToken) = UserLoginResponse(
         id = this.id,
-        email = this.email,
         token = token
 )

--- a/src/test/groovy/barter/barter_it_api/api/user/UserIT.groovy
+++ b/src/test/groovy/barter/barter_it_api/api/user/UserIT.groovy
@@ -32,7 +32,6 @@ class UserIT extends IntegrationSpec {
 
         then: 'expecting token'
             response.statusCode == OK
-            response.body.email == "email@example.com"
             response.body.token instanceof AccessToken
             response.body.token.expirationDate instanceof LocalDateTime
             response.body.token.value instanceof String


### PR DESCRIPTION
Obecnie niepotrzebnie zwracany jest email w procesie logowania